### PR TITLE
Adding skip tests option as I can't deploy package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
   slack-webhook-url:
     description: "the webhook URL to use when calling the Slack notification action"
     required: false
+  skip-tests:
+    description: "Whether to skip the Java tests. Override this to blank to run the tests."
+    required: false
+    default: " -DskipTests "
 runs:
   using: "composite"
   steps:
@@ -61,7 +65,7 @@ runs:
 
     - name: Maven package
       shell: bash
-      run: mvn package
+      run: mvn package ${{ inputs.skip-tests }}
       env:
         USERNAME: ${{ inputs.mvn-build-username }}
         PASSWORD: ${{ inputs.mvn-build-password }}


### PR DESCRIPTION
Sums up the sort of day I've had today 😆 

We've got broken integration tests presumably as Opayo have changed the sandbox behaviour. But I don't care about that RN.

<img width="400" alt="Screenshot 2024-08-15 at 18 09 41" src="https://github.com/user-attachments/assets/c4774b7e-bb52-4666-bd81-15d2f5faa3a6">

